### PR TITLE
Update other result.json print to use config path

### DIFF
--- a/src/main/java/io/riddles/matchwrapper/MatchWrapper.java
+++ b/src/main/java/io/riddles/matchwrapper/MatchWrapper.java
@@ -150,7 +150,7 @@ public class MatchWrapper implements Runnable {
     }
 
     private void saveGame(JSONObject result) throws IOException {
-        System.out.println("Writing to result.json");
+        System.out.println(String.format("Writing to %s", this.resultFilePath));
 
         FileWriter writer = new FileWriter(this.resultFilePath);
         writer.write(result.toString());


### PR DESCRIPTION
Commit 8454648 replaced one of the hardcoded "result.json" messages, but not the other one.